### PR TITLE
Add the navigator to the compose setup [PLEN-112]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,9 +169,7 @@ services:
       - "server"
       - "canton"
       - "10011"
-    volumes:
-      - logs:/var/log/promtail
-      
+
   ##
   ## Monitoring services
   ##


### PR DESCRIPTION
The navigator does not expose any metrics, but it completes the full daml setup