### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Use the `Makefile` — run `make help` for available commands!
 * Artifactory credentials to access our private
 [Canton Enterprise Docker images](https://digitalasset.jfrog.io/ui/repos/tree/General/canton-enterprise-docker/digitalasset/canton-enterprise/latest)
 
-Docker Compose will automagically build the [image for the HTTP JSON API service](daml-service/) from the release JAR file.
+Docker Compose will automagically build the [image for the HTTP JSON API service and Trigger service](daml-service/)
+from the release JAR files.
+
 Check the [`.env`](./.env) file to know which Canton and SDK versions are being used.
 
 ⚠️ You can test different versions changing `CANTON_VERSION` and `SDK_VERSION`, however, there is no guarantee that it will be

--- a/daml-service/Dockerfile
+++ b/daml-service/Dockerfile
@@ -11,9 +11,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && apt-get install --no-install-recommends -y curl
 
 ARG SDK_VERSION
+ENV SDK_VERSION="${SDK_VERSION}"
 ARG DAML_SERVICE
-ENV DAML_SERVICE=$DAML_SERVICE
+ENV DAML_SERVICE="${DAML_SERVICE}"
 COPY ./entrypoint.sh /opt/entrypoint.sh
-ADD https://github.com/digital-asset/daml/releases/download/v${SDK_VERSION}/${DAML_SERVICE}-${SDK_VERSION}.jar /opt/service.jar
+ADD "https://github.com/digital-asset/daml/releases/download/v${SDK_VERSION}/${DAML_SERVICE}-${SDK_VERSION}.jar" "/opt/${DAML_SERVICE}.jar"
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/daml-service/entrypoint.sh
+++ b/daml-service/entrypoint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 [[ -n ${VERBOSE:-} ]] && set -x
 
-# Log everything (stdout and stderr) to both log file and terminal
-exec > >(tee /var/log/promtail/"${DAML_SERVICE}".log) 2>&1
+# Bash trick - Log everything (stdout and stderr) to both log file and terminal
+exec > >(tee -a "/var/log/promtail/${DAML_SERVICE}.log") 2>&1
 
-eval "exec java -XX:+CrashOnOutOfMemoryError ${JAVA_OPTS:-} -jar /opt/service.jar \"\$@\""
+exec java -jar "/opt/${DAML_SERVICE}.jar" "${@}"

--- a/docker-compose-canton.yml
+++ b/docker-compose-canton.yml
@@ -12,7 +12,7 @@ services:
   postgres:
     # Oldest supported PostgreSQL version
     # https://www.postgresql.org/support/versioning/
-    image: postgres:11.18-bullseye
+    image: postgres:11.19-bullseye
     container_name: daml_observability_postgres
     environment:
       # For default admin user 'postgres'

--- a/docker-compose-canton.yml
+++ b/docker-compose-canton.yml
@@ -54,7 +54,7 @@ services:
       CANTON_AUTO_APPROVE_AGREEMENTS: "yes"
       CANTON_ALLOCATE_PARTIES: "alice;bob"
       CANTON_CONNECT_DOMAINS: "mydomain#http://localhost:10018"
-      JAVA_OPTS: "-Xmx3G"
+      JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx3G"
     command:
       - "daemon"
       - "--log-level-root=${LOG_LEVEL:-INFO}"
@@ -88,7 +88,7 @@ services:
     image: ${CANTON_IMAGE}:${CANTON_VERSION}
     container_name: daml_observability_canton_console
     environment:
-      JAVA_OPTS: "-Xmx1G"
+      JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx1G"
     entrypoint: ["tail", "-f", "/dev/null"]
     stop_grace_period: "0s"
     volumes:

--- a/docker-compose-daml-services.yml
+++ b/docker-compose-daml-services.yml
@@ -20,7 +20,7 @@ services:
       # Prometheus exporter
       - 19091:19091
     environment:
-      JAVA_OPTS: "-Xmx1G"
+      JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx1G"
     command:
       - "--log-level=${LOG_LEVEL:-INFO}"
       - "--log-encoder=json"
@@ -60,7 +60,7 @@ services:
       # Prometheus exporter
       - 19092:19090
     environment:
-      JAVA_OPTS: "-Xmx1G"
+      JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx1G"
       LOG_ENCODER_JSON: true
       LOG_LEVEL_ROOT: DEBUG
     command:
@@ -92,6 +92,8 @@ services:
       - "server"
       - "canton"
       - "10011"
+    environment:
+      JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx1G"
     depends_on:
       canton:
         condition: service_healthy

--- a/docker-compose-observability.yml
+++ b/docker-compose-observability.yml
@@ -14,7 +14,7 @@ services:
   prometheus:
     # Oldest Prometheus LTS version
     # https://prometheus.io/docs/introduction/release-cycle/
-    image: prom/prometheus:v2.37.5
+    image: prom/prometheus:v2.37.6
     container_name: daml_observability_prometheus
     command:
       # Prometheus configuration
@@ -37,7 +37,7 @@ services:
   grafana:
     # Latest Grafana version
     # https://grafana.com/docs/grafana/latest/release-notes/
-    image: grafana/grafana:9.3.6-ubuntu
+    image: grafana/grafana:9.3.11-ubuntu
     container_name: daml_observability_grafana
     volumes:
       # Grafana configuration
@@ -76,7 +76,7 @@ services:
       - ./postgres/postgres_exporter.yml:/postgres_exporter.yml
 
   loki:
-    image: grafana/loki:2.7.3
+    image: grafana/loki:2.7.5
     container_name: daml_observability_loki
     command: -config.file=/etc/loki/loki.yaml
     volumes:
@@ -88,7 +88,7 @@ services:
       - promtail
 
   promtail:
-    image: grafana/promtail:2.7.3
+    image: grafana/promtail:2.7.5
     container_name: daml_observability_promtail
     command: -config.file=/etc/promtail/promtail.yml
     volumes:


### PR DESCRIPTION
* Use explicit `JDK_JAVA_OPTIONS` in Docker Compose (picked up in Java 9+) instead of using custom `-XX:+CrashOnOutOfMemoryError` + `JAVA_OPTS` in Daml services docker image entrypoint
* Avoid overwriting docker cache layer using the same file name in `ADD` statement
* Bump:
  * Postgres to 11.9 (oldest supported version)
  * Prometheus to 2.37.6 (LTS)
  * Grafana 9.3.11
  * Loki + Promtail 2.7.5