### PR TITLE
'true' to '1' for compatibility w/ docker-compose

### DIFF
--- a/docker-compose-daml-services.yml
+++ b/docker-compose-daml-services.yml
@@ -61,7 +61,7 @@ services:
       - 19092:19090
     environment:
       JDK_JAVA_OPTIONS: "-XX:+CrashOnOutOfMemoryError -Xmx1G"
-      LOG_ENCODER_JSON: true
+      LOG_ENCODER_JSON: 1
       LOG_LEVEL_ROOT: DEBUG
     command:
       - "--config=/trigger-service/config.conf"

--- a/docker-compose-observability.yml
+++ b/docker-compose-observability.yml
@@ -74,7 +74,7 @@ services:
       DATA_SOURCE_USER: "postgres"
       DATA_SOURCE_PASS: "postgres"
       DATA_SOURCE_URI: "postgres:5432/postgres?sslmode=disable"
-      PG_EXPORTER_AUTO_DISCOVER_DATABASES: true
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: 1
     volumes:
       # PostgreSQL Server Exporter configuration
       - ./postgres/postgres_exporter.yml:/postgres_exporter.yml


### PR DESCRIPTION
When I clone and run:
```bash
daml-platform-observability-example$ sudo docker-compose up
```

I get the following errors:

In file, `docker-compose-observability.yml`

> **ERROR**: The Compose file './docker-compose-observability.yml' is invalid because:
> services.postgres-exporter.environment.PG_EXPORTER_AUTO_DISCOVER_DATABASES contains true, which is an invalid type, it should be a string, number, or a null
> 

In file, `docker-compose-daml-services.yml`

> **ERROR**: The Compose file './docker-compose-daml-services.yml' is invalid because:
> services.trigger-service.environment.LOG_ENCODER_JSON contains true, which is an invalid type, it should be a string, number, or a null

Issue described here:
https://github.com/digital-asset/daml-platform-observability-example/issues/29