### PR TITLE
Adjust metric unit for GC total time in JVM dashboard

### DIFF
--- a/grafana/dashboards/Platform/jvm-metrics.json
+++ b/grafana/dashboards/Platform/jvm-metrics.json
@@ -183,7 +183,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },


### PR DESCRIPTION
Fix for #27 