### PR TITLE
Explain how to query Loki for logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ docker compose down --volumes
 
 * Prometheus: http://localhost:9090/
 * Grafana: http://localhost:3000/ (default user and password: `digitalasset`)
-* Loki: http://localhost:5000/ (default user and password: `digitalasset`)
 * Participant's Ledger API endpoint: http://localhost:10011/
+* HTTP JSON API endpoint: http://localhost:4001/
 
 Check all exposed services/ports in the different [Docker compose YAML] files:
 * [Canton](./docker-compose-canton.yml)
@@ -141,6 +141,12 @@ docker logs -f daml_observability_postgres
 docker logs -f daml_observability_prometheus
 docker logs -f daml_observability_grafana
 ```
+
+You can query Loki for logs [using Grafana in the `Explore` section](http://localhost:3000/explore?left=%7B%22datasource%22:%22loki%22%7D).
+
+### Metrics
+
+You can query Prometheus for metrics [using Grafana in the `Explore` section](http://localhost:3000/explore?left=%7B%22datasource%22:%22prometheus%22%7D).
 
 ## Configuration
 
@@ -178,12 +184,21 @@ All dashboards (JSON files) are auto-loaded from directory
 * Automatic: place your JSON files in the folder (loaded at startup, reloaded every 30 seconds)
 * Manual: create/edit via Grafana UI
 
+### Loki
+
+* Loki itself: [`loki.yaml`](./loki/loki.yaml) [[documentation]](https://grafana.com/docs/loki/latest/configure/)
+
+Restart on changes: `docker compose restart loki`
+
+* Promtail: [`promtail.yaml`](./loki/promtail.yaml) [[documentation]](https://grafana.com/docs/loki/latest/send-data/promtail/configuration/)
+
+Restart on changes: `docker compose restart promtail`
+
 ##### Examples Source
 
 * Prometheus and Grafana [[source]](https://github.com/grafana/grafana/tree/main/public/app/plugins/datasource/prometheus/dashboards/)
 * Node exporter full [[source]](https://grafana.com/grafana/dashboards/1860-node-exporter-full/)
 * Loki and Promtail [[source]](https://grafana.com/grafana/dashboards/14055-loki-stack-monitoring-promtail-loki/)
-
 
 ## Accessing Daml Enterprise container images
 

--- a/grafana/dashboards/home.json
+++ b/grafana/dashboards/home.json
@@ -7,8 +7,8 @@
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 23,
-        "w": 7,
+        "h": 25,
+        "w": 8,
         "x": 0,
         "y": 0
       },
@@ -19,7 +19,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "**Endpoints**\n\n| Link | URL |\n|---|---|\n| <a href=\"http://localhost:9090/\" target=\"_blank\">Prometheus</a> | `http://localhost:9090/`\n| <a href=\"http://localhost:5100/\" target=\"_blank\">Promtail</a> | `http://localhost:5100/`\n| <a href=\"http://localhost:3000/\" target=\"_blank\">Grafana</a> | `http://localhost:3000/`\n| <a href=\"http://localhost:10011/\" target=\"_blank\">Ledger API</a> | `http://localhost:10011/`\n| <a href=\"http://localhost:4001/\" target=\"_blank\">HTTP JSON API</a> | `http://localhost:4001/`\n\n**Metrics**\n\n| Link | URL |\n|---|---|\n| <a href=\"http://localhost:9090/metrics\" target=\"_blank\">Prometheus</a> | `http://localhost:9090/metrics`\n| <a href=\"http://localhost:5000/metrics\" target=\"_blank\">Loki</a> | `http://localhost:5000/metrics`\n| <a href=\"http://localhost:5100/metrics\" target=\"_blank\">Promtail</a> | `http://localhost:5100/metrics`\n| <a href=\"http://localhost:3000/metrics\" target=\"_blank\">Grafana</a> | `http://localhost:3000/metrics`\n| <a href=\"http://localhost:9100/metrics\" target=\"_blank\">Node Exporter</a> | `http://localhost:9100/metrics`\n| <a href=\"http://localhost:19090/metrics\" target=\"_blank\">Ledger API</a> | `http://localhost:19090/metrics`\n| <a href=\"http://localhost:19091/metrics\" target=\"_blank\">HTTP JSON API</a> | `http://localhost:19091/metrics`",
+        "content": "**Endpoints accessible locally from your browser**\n\n| Link | URL |\n|---|---|\n| <a href=\"http://localhost:9090/\" target=\"_blank\">Prometheus</a> | `http://localhost:9090/`\n| <a href=\"http://localhost:3000/\" target=\"_blank\">Grafana</a> | `http://localhost:3000/`\n| <a href=\"http://localhost:10011/\" target=\"_blank\">Ledger API</a> | `http://localhost:10011/`\n| <a href=\"http://localhost:4001/\" target=\"_blank\">HTTP JSON API</a> | `http://localhost:4001/`\n\n**Exporters scraped by Prometheus inside the Docker Compose network**\n\n| Link | URL |\n|---|---|\n| <a href=\"http://localhost:9090/metrics\" target=\"_blank\">Prometheus</a> | `http://localhost:9090/metrics`\n| Loki | `http://localhost:5000/metrics`\n| Promtail | `http://localhost:5100/metrics`\n| <a href=\"http://localhost:3000/metrics\" target=\"_blank\">Grafana</a> | `http://localhost:3000/metrics`\n| Node Exporter | `http://localhost:9100/metrics`\n| <a href=\"http://localhost:19090/metrics\" target=\"_blank\">Ledger API</a> | `http://localhost:19090/metrics`\n| <a href=\"http://localhost:19091/metrics\" target=\"_blank\">HTTP JSON API</a> | `http://localhost:19091/metrics`",
         "mode": "markdown"
       },
       "title": "Daml Platform - Observability Example",
@@ -32,9 +32,9 @@
       },
       "description": "",
       "gridPos": {
-        "h": 23,
+        "h": 25,
         "w": 10,
-        "x": 7,
+        "x": 8,
         "y": 0
       },
       "id": 2,


### PR DESCRIPTION
Follow-up of https://discuss.daml.com/t/no-loki-ui-in-daml-platform-observability-example/6884
* Go to Grafana > Explore section
* Reworked default "home" dashboard to avoid misleading user into accessing endpoints not exposed by Compose