### PR TITLE
Add dashboard for PQS/Scribe

### DIFF
--- a/.env
+++ b/.env
@@ -6,4 +6,4 @@ COMPOSE_FILE=docker-compose-observability.yml:docker-compose-canton.yml:docker-c
 
 # extras
 SCRIBE_IMAGE=digitalasset-docker.jfrog.io/participant-query-store
-SCRIBE_VERSION=0.1.0
+SCRIBE_VERSION=0.4.4

--- a/extras/pqs_scribe.conf
+++ b/extras/pqs_scribe.conf
@@ -1,6 +1,7 @@
 {
   # uncomment to write to the choices tables
   # pipeline.datasource = "TransactionTreeStream"
+  pipeline.ledger.start = Oldest
   source {
     ledger {
       host = "canton"

--- a/grafana/dashboards/Participant/pqs-scribe.json
+++ b/grafana/dashboards/Participant/pqs-scribe.json
@@ -1,0 +1,2631 @@
+{
+   "annotations": {
+      "list": [
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$prom_src"
+            },
+            "enable": true,
+            "expr": "(grpc_up{job=\"$jvm_job\"} < 1) + 1",
+            "hide": false,
+            "iconColor": "red",
+            "name": "Ledger availability",
+            "titleFormat": "Ledger down"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$prom_src"
+            },
+            "enable": true,
+            "expr": "(jdbc_conn_pool_up{job=\"$jvm_job\"} < 1) + 1",
+            "hide": false,
+            "iconColor": "dark-red",
+            "name": "Datastore availability",
+            "titleFormat": "Datastore down"
+         }
+      ]
+   },
+   "description": "Dashboard for monitoring application metrics",
+   "graphTooltip": 1,
+   "panels": [
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 1,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": null,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 2,
+               "interval": "10s",
+               "options": {
+                  "legend": {
+                     "displayMode": "table",
+                     "placement": "right"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "label_replace(rate(pipeline_events_total{job=\"$jvm_job\",type=\"create\"}[$__rate_interval]) * 1, \"short_template\", \"$1\", \"template\", \".*?:(.*)\")",
+                     "legendFormat": "{{short_template}}"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "label_replace(rate(pipeline_events_total{job=\"$jvm_job\",type=\"archive\"}[$__rate_interval]) * -1, \"short_template\", \"$1\", \"template\", \".*?:(.*)\")",
+                     "legendFormat": "{{short_template}}"
+                  }
+               ],
+               "title": "Churn",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "description": "* as observed since last restart",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 3,
+               "interval": "10s",
+               "options": {
+                  "legend": {
+                     "calcs": [
+                        "lastNotNull",
+                        "max"
+                     ],
+                     "displayMode": "table",
+                     "placement": "right"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "label_replace(sum without(type) (pipeline_events_total{job=\"$jvm_job\",type=\"create\"}) - ((sum without(type) (pipeline_events_total{job=\"$jvm_job\",type=\"archive\"})) or (sum without(type) (pipeline_events_total{job=\"$jvm_job\",type=\"create\"})*0)), \"short_template\", \"$1\", \"template\", \".*?:(.*)\")",
+                     "legendFormat": "{{short_template}}"
+                  }
+               ],
+               "title": "Active *",
+               "type": "timeseries"
+            }
+         ],
+         "title": "Contracts",
+         "type": "row"
+      },
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 4,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 5,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(watermark_ix{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "watermark index"
+                  }
+               ],
+               "title": "Watermark history",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "decimals": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 6,
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(watermark_ix{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "watermark index"
+                  }
+               ],
+               "title": "Current watermark throughput",
+               "type": "gauge"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "color": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                     },
+                     "decimals": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 0
+               },
+               "id": 7,
+               "options": {
+                  "graphMode": "none"
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "watermark_ix{job=\"$jvm_job\"}"
+                  }
+               ],
+               "title": "Ledger transactions ingested",
+               "type": "stat"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 8,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_events_total{job=\"$jvm_job\",type=\"transaction\"}[$__rate_interval])",
+                     "legendFormat": "transactions"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(rate(pipeline_events_total{job=\"$jvm_job\",type=~\"(create|archive|exercise)\"}[$__rate_interval]))",
+                     "legendFormat": "events"
+                  }
+               ],
+               "title": "Transactions and events",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 10,
+                        "showPoints": "never",
+                        "spanNulls": true,
+                        "stacking": {
+                           "mode": "normal"
+                        }
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 8
+               },
+               "id": 9,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(rate(pipeline_events_total{job=\"$jvm_job\",type=\"create\"}[$__rate_interval]))",
+                     "legendFormat": "creates"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(rate(pipeline_events_total{job=\"$jvm_job\",type=\"archive\"}[$__rate_interval]))",
+                     "legendFormat": "archives"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(rate(pipeline_events_total{job=\"$jvm_job\",type=\"exercise\"}[$__rate_interval]))",
+                     "legendFormat": "exercises"
+                  }
+               ],
+               "title": "Events breakdown",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 16
+               },
+               "id": 10,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_events_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "ledger events"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "statements"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_batched_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "batches"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_prepared_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "prepared statements"
+                  }
+               ],
+               "title": "Waitpoints - ACS",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "ops"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 16
+               },
+               "id": 11,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_events_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "ledger events"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "statements"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_batched_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "batches"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_prepared_statements_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "prepared statements"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_watermarks_total{job=\"$jvm_job\"}[$__rate_interval])",
+                     "legendFormat": "watermarks"
+                  }
+               ],
+               "title": "Waitpoints - streaming",
+               "type": "timeseries"
+            }
+         ],
+         "title": "Throughput",
+         "type": "row"
+      },
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 12,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 13,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_events_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Events",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 14,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Statements",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 15,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_batched_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Batched statements",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 8
+               },
+               "id": 16,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_acs_prepared_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Prepared statements",
+               "type": "heatmap"
+            }
+         ],
+         "title": "Queues sizes - ACS",
+         "type": "row"
+      },
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 17,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 18,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_events_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Events",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 19,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Statements",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 20,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_batched_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Batched statements",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 8
+               },
+               "id": 21,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_prepared_statements_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Prepared statements",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     },
+                     "max": 32,
+                     "min": 0
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 16
+               },
+               "id": 22,
+               "interval": "10s",
+               "options": {
+                  "cellGap": 0,
+                  "color": {
+                     "fill": "dark-green",
+                     "max": 32,
+                     "min": 0,
+                     "mode": "opacity",
+                     "scale": "linear",
+                     "steps": 32
+                  },
+                  "filterValues": {
+                     "le": 0
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "hidden"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_wp_watermarks_size_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Watermarks",
+               "type": "heatmap"
+            }
+         ],
+         "title": "Queues sizes - streaming",
+         "type": "row"
+      },
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 23,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "auto",
+                        "spanNulls": false
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "s"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "p50",
+                                 "p90",
+                                 "p95",
+                                 "p99"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p99"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "red",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p95"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "orange",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p90"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "yellow",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p50"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "green",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "throughput"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "ops"
+                           },
+                           {
+                              "id": "custom.lineWidth",
+                              "value": 2
+                           },
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "text",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 24,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.50, sum by(le) (rate(pipeline_convert_acs_event_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p50"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.90, sum by(le) (rate(pipeline_convert_acs_event_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p90"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.95, sum by(le) (rate(pipeline_convert_acs_event_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p95"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.99, sum by(le) (rate(pipeline_convert_acs_event_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p99"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_convert_acs_event_count[$__rate_interval])",
+                     "legendFormat": "throughput"
+                  }
+               ],
+               "title": "Convert event - ACS",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 25,
+               "interval": "10s",
+               "options": {
+                  "cellValues": {
+                     "decimals": 0,
+                     "unit": "short"
+                  },
+                  "color": {
+                     "fill": "dark-green",
+                     "mode": "opacity",
+                     "scheme": "Greens",
+                     "steps": 128
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "right",
+                     "axisWidth": 60,
+                     "decimals": 0,
+                     "unit": "s"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_convert_acs_event_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Convert event - ACS",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "auto",
+                        "spanNulls": false
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "s"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "p50",
+                                 "p90",
+                                 "p95",
+                                 "p99"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p99"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "red",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p95"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "orange",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p90"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "yellow",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p50"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "green",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "throughput"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "ops"
+                           },
+                           {
+                              "id": "custom.lineWidth",
+                              "value": 2
+                           },
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "text",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 26,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.50, sum by(le) (rate(pipeline_convert_transaction_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p50"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.90, sum by(le) (rate(pipeline_convert_transaction_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p90"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.95, sum by(le) (rate(pipeline_convert_transaction_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p95"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.99, sum by(le) (rate(pipeline_convert_transaction_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p99"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_convert_transaction_count[$__rate_interval])",
+                     "legendFormat": "throughput"
+                  }
+               ],
+               "title": "Convert transaction - streaming",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 8
+               },
+               "id": 27,
+               "interval": "10s",
+               "options": {
+                  "cellValues": {
+                     "decimals": 0,
+                     "unit": "short"
+                  },
+                  "color": {
+                     "fill": "dark-green",
+                     "mode": "opacity",
+                     "scheme": "Greens",
+                     "steps": 128
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "right",
+                     "axisWidth": 60,
+                     "decimals": 0,
+                     "unit": "s"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_convert_transaction_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Convert transaction - streaming",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "auto",
+                        "spanNulls": false
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "s"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "p50",
+                                 "p90",
+                                 "p95",
+                                 "p99"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p99"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "red",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p95"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "orange",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p90"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "yellow",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p50"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "green",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "throughput"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "ops"
+                           },
+                           {
+                              "id": "custom.lineWidth",
+                              "value": 2
+                           },
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "text",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 16
+               },
+               "id": 28,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.50, sum by(le) (rate(pipeline_prepare_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p50"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.90, sum by(le) (rate(pipeline_prepare_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p90"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.95, sum by(le) (rate(pipeline_prepare_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p95"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.99, sum by(le) (rate(pipeline_prepare_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p99"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_prepare_batch_latency_count[$__rate_interval])",
+                     "legendFormat": "throughput"
+                  }
+               ],
+               "title": "Prepare batch",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 16
+               },
+               "id": 29,
+               "interval": "10s",
+               "options": {
+                  "cellValues": {
+                     "decimals": 0,
+                     "unit": "short"
+                  },
+                  "color": {
+                     "fill": "dark-green",
+                     "mode": "opacity",
+                     "scheme": "Greens",
+                     "steps": 128
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "right",
+                     "axisWidth": 60,
+                     "decimals": 0,
+                     "unit": "s"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_prepare_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Prepare batch",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "auto",
+                        "spanNulls": false
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "s"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "p50",
+                                 "p90",
+                                 "p95",
+                                 "p99"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p99"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "red",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p95"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "orange",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p90"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "yellow",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p50"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "green",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "throughput"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "ops"
+                           },
+                           {
+                              "id": "custom.lineWidth",
+                              "value": 2
+                           },
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "text",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 24
+               },
+               "id": 30,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.50, sum by(le) (rate(pipeline_execute_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p50"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.90, sum by(le) (rate(pipeline_execute_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p90"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.95, sum by(le) (rate(pipeline_execute_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p95"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.99, sum by(le) (rate(pipeline_execute_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p99"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_execute_batch_latency_count[$__rate_interval])",
+                     "legendFormat": "throughput"
+                  }
+               ],
+               "title": "Execute batch",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 24
+               },
+               "id": 31,
+               "interval": "10s",
+               "options": {
+                  "cellValues": {
+                     "decimals": 0,
+                     "unit": "short"
+                  },
+                  "color": {
+                     "fill": "dark-green",
+                     "mode": "opacity",
+                     "scheme": "Greens",
+                     "steps": 128
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "right",
+                     "axisWidth": 60,
+                     "decimals": 0,
+                     "unit": "s"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(pipeline_execute_batch_latency_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "Execute batch",
+               "type": "heatmap"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "auto",
+                        "spanNulls": false
+                     },
+                     "decimals": null,
+                     "min": 0,
+                     "unit": "s"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "p50",
+                                 "p90",
+                                 "p95",
+                                 "p99"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p99"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "red",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p95"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "orange",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p90"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "yellow",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "p50"
+                        },
+                        "properties": [
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "green",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "throughput"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "ops"
+                           },
+                           {
+                              "id": "custom.lineWidth",
+                              "value": 2
+                           },
+                           {
+                              "id": "color",
+                              "value": {
+                                 "fixedColor": "text",
+                                 "mode": "fixed"
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 32
+               },
+               "id": 32,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.50, sum by(le) (rate(jdbc_conn_use_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p50"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.90, sum by(le) (rate(jdbc_conn_use_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p90"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.95, sum by(le) (rate(jdbc_conn_use_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p95"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "histogram_quantile(0.99, sum by(le) (rate(jdbc_conn_use_bucket{job=\"$jvm_job\"}[$__rate_interval])))",
+                     "legendFormat": "p99"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(jdbc_conn_use_count[$__rate_interval])",
+                     "legendFormat": "throughput"
+                  }
+               ],
+               "title": "JDBC connection",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "scaleDistribution": "linear"
+                     }
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 32
+               },
+               "id": 33,
+               "interval": "10s",
+               "options": {
+                  "cellValues": {
+                     "decimals": 0,
+                     "unit": "short"
+                  },
+                  "color": {
+                     "fill": "dark-green",
+                     "mode": "opacity",
+                     "scheme": "Greens",
+                     "steps": 128
+                  },
+                  "legend": {
+                     "show": false
+                  },
+                  "yAxis": {
+                     "axisPlacement": "right",
+                     "axisWidth": 60,
+                     "decimals": 0,
+                     "unit": "s"
+                  }
+               },
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "rate(jdbc_conn_use_bucket{job=\"$jvm_job\"}[$__rate_interval])",
+                     "format": "heatmap",
+                     "legendFormat": "{{label_name}}"
+                  }
+               ],
+               "title": "JDBC connection",
+               "type": "heatmap"
+            }
+         ],
+         "title": "Latency",
+         "type": "row"
+      },
+      {
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0
+         },
+         "id": 34,
+         "panels": [
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 10,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "bytes"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "used",
+                                 "committed"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 35,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(jvm_memory_used_bytes{job=\"$jvm_job\", jvm_memory_type=\"heap\"}) by(jvm_memory_type)",
+                     "legendFormat": "used"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(jvm_memory_committed_bytes{job=\"$jvm_job\", jvm_memory_type=\"heap\"}) by(jvm_memory_type)",
+                     "legendFormat": "committed"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(jvm_memory_limit_bytes{job=\"$jvm_job\", jvm_memory_type=\"heap\"}) by(jvm_memory_type)",
+                     "legendFormat": "max"
+                  }
+               ],
+               "title": "Heap memory",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 0,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "short"
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byRegexp",
+                           "options": "/.*\\(time\\)/"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "decimals",
+                              "value": null
+                           },
+                           {
+                              "id": "custom.fillOpacity",
+                              "value": 10
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 0
+               },
+               "id": 36,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(idelta(jvm_gc_duration_seconds_count{job=\"$jvm_job\"}[$__rate_interval])) by(jvm_gc_name)",
+                     "legendFormat": "{{jvm_gc_name}} (count)"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "sum(idelta(jvm_gc_duration_seconds_sum{job=\"$jvm_job\"}[$__rate_interval])) by(jvm_gc_name)",
+                     "legendFormat": "{{jvm_gc_name}} (time)"
+                  }
+               ],
+               "title": "Garbage collection",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 10,
+                        "showPoints": "never",
+                        "spanNulls": true,
+                        "stacking": {
+                           "mode": "normal"
+                        }
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "short"
+                  }
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 0
+               },
+               "id": 37,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "jvm_thread_count{job=\"$jvm_job\"}",
+                     "legendFormat": "{{jvm_thread_state}}"
+                  }
+               ],
+               "title": "Threads",
+               "type": "timeseries"
+            },
+            {
+               "datasource": {
+                  "type": "datasource",
+                  "uid": "-- Mixed --"
+               },
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "fillOpacity": 10,
+                        "showPoints": "never",
+                        "spanNulls": true
+                     },
+                     "decimals": 0,
+                     "min": 0,
+                     "unit": "bytes"
+                  },
+                  "overrides": [
+                     {
+                        "__systemRef": "hideSeriesFrom",
+                        "matcher": {
+                           "id": "byNames",
+                           "options": {
+                              "mode": "exclude",
+                              "names": [
+                                 "used",
+                                 "committed",
+                                 "allocated"
+                              ],
+                              "prefix": "All except:",
+                              "readOnly": true
+                           }
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hideFrom",
+                              "value": {
+                                 "legend": false,
+                                 "tooltip": false,
+                                 "viz": true
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "allocated"
+                        },
+                        "properties": [
+                           {
+                              "id": "unit",
+                              "value": "binBps"
+                           },
+                           {
+                              "id": "custom.fillOpacity",
+                              "value": 0
+                           }
+                        ]
+                     }
+                  ]
+               },
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 8
+               },
+               "id": 38,
+               "interval": "10s",
+               "pluginVersion": "v9.5.0",
+               "repeat": "jvm_mempool",
+               "repeatDirection": "h",
+               "targets": [
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "jvm_memory_used_bytes{job=\"$jvm_job\", jvm_memory_pool_name=\"$jvm_mempool\"}",
+                     "legendFormat": "used"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "jvm_memory_committed_bytes{job=\"$jvm_job\", jvm_memory_pool_name=\"$jvm_mempool\"}",
+                     "legendFormat": "committed"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "jvm_memory_limit_bytes{job=\"$jvm_job\", jvm_memory_pool_name=\"$jvm_mempool\"}",
+                     "legendFormat": "max"
+                  },
+                  {
+                     "datasource": {
+                        "type": "prometheus",
+                        "uid": "$prom_src"
+                     },
+                     "expr": "irate(jvm_memory_used_bytes{job=\"$jvm_job\", jvm_memory_pool_name=\"$jvm_mempool\"}[$__rate_interval])",
+                     "legendFormat": "allocated"
+                  }
+               ],
+               "title": "Memory pool - $jvm_mempool",
+               "type": "timeseries"
+            }
+         ],
+         "title": "JVM metrics",
+         "type": "row"
+      }
+   ],
+   "refresh": "10s",
+   "schemaVersion": 36,
+   "templating": {
+      "list": [
+         {
+            "description": "Metrics source",
+            "label": "Source",
+            "name": "prom_src",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${prom_src}"
+            },
+            "description": "JVM jobs",
+            "label": "Job",
+            "name": "jvm_job",
+            "query": "label_values(jvm_cpu_time_seconds_total, job)",
+            "refresh": 1,
+            "type": "query"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${prom_src}"
+            },
+            "description": "JVM memory pools",
+            "hide": 2,
+            "includeAll": true,
+            "label": "MemPool",
+            "name": "jvm_mempool",
+            "query": "label_values(jvm_memory_used_after_last_gc_bytes{job=\"$jvm_job\"}, jvm_memory_pool_name)",
+            "refresh": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-5m",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "PQS / Scribe",
+   "uid": "pqs-scribe"
+}

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -62,3 +62,8 @@ scrape_configs:
       - targets:
           # Docker compose service
           - postgres-exporter:9187
+  - job_name: pqs_scribe
+    static_configs:
+      - targets:
+          # Docker compose service
+          - pqs_scribe:9090


### PR DESCRIPTION
This PR adds dashboard that highlights the most interesting metrics emitted by PQS/Scribe application.

![pqs-scribe](https://github.com/digital-asset/daml-platform-observability-example/assets/389402/83648547-2c18-40aa-b1bf-66972a014dc3)
